### PR TITLE
fix: dependabot is on wrong location

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,12 @@
 
 version: 2
 updates:
-    - package-ecosystem: "swift" # See documentation for possible values
-        directory: "/" # Location of package manifests
-        schedule:
-        interval: "weekly"
-    - package-ecosystem: "github-actions" # Recommended to keep tools up-to-date
-        directory: "/"
-        schedule:
-        interval: "weekly"
+- package-ecosystem: "swift" # See documentation for possible values
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "weekly"
+    
+- package-ecosystem: "github-actions" # Recommended to keep tools up-to-date
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
Enable dependabot for swift and github actions

- don't locate this in workflows