### PR TITLE
fix: wrong renovate github action version

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Run Renovate
-        uses: renovatebot/github-action@v3
+        uses: renovatebot/github-action@v44.2.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           configurationFile: renovate.json


### PR DESCRIPTION
# Issues
- Action version was wrong
- #12 

# Solution 
- Update with latest example of https://github.com/renovatebot/github-action

# Result
<img width="427" height="279" alt="스크린샷 2026-01-28 오전 9 46 03" src="https://github.com/user-attachments/assets/5276977f-6de1-4f5b-a16d-d8cd71a072bb" />
