### PR TITLE
fix: set renovate workflow repositories  #20 no repositories found

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           configurationFile: renovate.json
-          repositories: ${{ github.repository }}
         env:
           LOG_LEVEL: 'debug'
+          RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
# Warning
[renovate](https://github.com/2sem/democracyAction-app-ios/actions/runs/21440520999/job/61742111043#step:3:1)
Unexpected input(s) 'repositories', valid inputs are ['configurationFile', 'token', 'env-regex', 'renovate-version', 'renovate-image', 'mount-docker-socket', 'docker-socket-host-path', 'docker-cmd-file', 'docker-network', 'docker-user', 'docker-volumes']

# Solution
GitHub Action doesn't have option for repositories, so use env

fix #20