### PR TITLE
fix: renovate don't create pr due to schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "labels": ["dependencies", "renovate"],
   "prConcurrentLimit": 3,
   "prHourlyLimit": 2,
-  "schedule": ["before 3am on monday"],
+  "schedule": [],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
# Issue
- #30 

# Solution
Remove `schedule` from config

# Result
<img width="670" height="499" alt="스크린샷 2026-01-29 오후 2 10 47" src="https://github.com/user-attachments/assets/bfa8a443-8d78-4a33-93b8-66545398eb52" />
