### PR TITLE
ci: grant oidc to codeql ci: Ensure your workflow has 'permissions: id-token: write' set

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,9 @@ jobs:
       actions: read
       contents: read
 
+      # required for Tuist OIDC authentication
+      id-token: write
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# Issues
- #46

Fixes #46