### PR TITLE
fix: set iOS 18.0 deployment target for DynamicThirdParty and ThirdParty

### DIFF
--- a/Projects/DynamicThirdParty/Project.swift
+++ b/Projects/DynamicThirdParty/Project.swift
@@ -13,6 +13,7 @@ let project = Project(
             destinations: .iOS,
             product: .framework,
             bundleId: .appBundleId.appending(".thirdparty.dynamic"),
+            deploymentTargets: .iOS("18.0"),
             dependencies: [
                 .package(product: "SDWebImage"),
                 .package(product: "FirebaseCrashlytics"),

--- a/Projects/ThirdParty/Project.swift
+++ b/Projects/ThirdParty/Project.swift
@@ -27,6 +27,7 @@ let project = Project(
             destinations: .iOS,
             product: .staticFramework,
             bundleId: .appBundleId.appending(".thirdparty"),
+            deploymentTargets: .iOS("18.0"),
             dependencies: [.package(product: "CoreXLSX"),
                            .package(product: "KakaoSDK", type: .runtime),
                            .package(product: "SwipeCellKit"),


### PR DESCRIPTION
### Summary
Fixed deployment target mismatch by setting iOS 18.0 as the deployment target for both DynamicThirdParty and ThirdParty frameworks.

### Changes
- Added `deploymentTargets: .iOS("18.0")` to DynamicThirdParty/Project.swift
- Added `deploymentTargets: .iOS("18.0")` to ThirdParty/Project.swift

Fixes #65

Generated with [Claude Code](https://claude.ai/code)