### PR TITLE
fix: replace unused 'person' variables with '_'

### DIFF
--- a/Projects/App/Sources/Database/DAModelController+DAEventInfo.swift
+++ b/Projects/App/Sources/Database/DAModelController+DAEventInfo.swift
@@ -50,11 +50,11 @@ extension DAModelController{
                         continue;
                 }
                 
-                if name == nameCho, let person = member.person{
+                if name == nameCho, let _ = member.person{
                     filter = nameFirstCharacters.contains(nameCho);
                 }else if !name.isEmpty{
                     filter = name.contains(nameCho);
-                    if !filter && !nameKors.isEmpty, let person = member.person{
+                    if !filter && !nameKors.isEmpty, let _ = member.person{
                         filter = nameCharacters.contains(nameKors);
                     }
                 }


### PR DESCRIPTION
## Summary
- Fixed Swift compiler warnings in DAModelController+DAEventInfo.swift
- Replaced unused 'person' variable bindings with '_' at lines 53 and 57

Closes #66

Generated with [Claude Code](https://claude.ai/code)