### PR TITLE
fix: replace deprecated 'index(of:)' with 'firstIndex(of:)'

### DIFF
--- a/Projects/App/Sources/Database/DAModelController+DAExcelController.swift
+++ b/Projects/App/Sources/Database/DAModelController+DAExcelController.swift
@@ -36,8 +36,8 @@ extension DAModelController{
                 continue;
             }
             
-            //find 
-            if let index = modelPersons.index(of: modelPerson){
+            //find
+            if let index = modelPersons.firstIndex(of: modelPerson){
                 modelPersons.remove(at: index);
             }
         }


### PR DESCRIPTION
Replace deprecated 'index(of:)' method with 'firstIndex(of:)' in DAModelController+DAExcelController.swift to resolve compiler warning.

Fixes #67

Generated with [Claude Code](https://claude.ai/code)