### PR TITLE
fix: add AccentColor to main app asset catalog

### DIFF
--- a/Projects/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Projects/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
Adds AccentColor.colorset to Projects/App/Resources/Assets.xcassets to resolve the warning "Accent color 'AccentColor' is not present in any asset catalogs."

Closes #76

Generated with [Claude Code](https://claude.ai/code)