### PR TITLE
fix: resolve optional string interpolation warning in DAExcelController

### DIFF
--- a/Projects/App/Sources/Excel/DAExcelController.swift
+++ b/Projects/App/Sources/Excel/DAExcelController.swift
@@ -91,7 +91,7 @@ class DAExcelController : NSObject{
     override convenience init(){
         
         if DADefaults.DataDownloaded{
-            print("DAExcelController init. localUrl: \(DAExcelController.localUrl)")
+            print("DAExcelController init. localUrl: \(DAExcelController.localUrl?.absoluteString ?? "nil")")
             let downloadedExcel = DAExcelController(DAExcelController.localUrl!)
 //            let downloadedExcel = XLSXFile.init(filepath: DAExcelController.localUrl!.path)!
 //            let downloadedWorkbook = try! downloadedExcel.parseWorkbooks().first!


### PR DESCRIPTION
Use `.absoluteString ?? "nil"` to explicitly handle the optional URL in the print statement, resolving the Swift compiler warning at line 94.

Fixes #77

Generated with [Claude Code](https://claude.ai/code)