### PR TITLE
chore: migrate SPM packages to Tuist registry

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -1,12 +1,12 @@
 {
-  "originHash" : "33376a08ddb1f20bb7c40022cc49fdebd5353d53703da7f1a682188f74d547b2",
+  "originHash" : "85954ae1ea91194846ae3476dbfd6a8b7a8582382ac21e1a3ebcc663c8b699ca",
   "pins" : [
     {
-      "identity" : "Alamofire.Alamofire",
+      "identity" : "alamofire.alamofire",
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "5.11.0"
+        "version" : "5.11.1"
       }
     },
     {
@@ -164,11 +164,10 @@
       }
     },
     {
-      "identity" : "kakao-ios-sdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "identity" : "kakao.kakao-ios-sdk",
+      "kind" : "registry",
+      "location" : "",
       "state" : {
-        "revision" : "5978979157a5a0521c9c56fd0156aec794caa21c",
         "version" : "2.27.2"
       }
     },

--- a/Projects/ThirdParty/Project.swift
+++ b/Projects/ThirdParty/Project.swift
@@ -4,8 +4,7 @@ import ProjectDescriptionHelpers
 let project = Project(
     name: "ThirdParty",
     packages: [
-        .remote(url: "https://github.com/kakao/kakao-ios-sdk",
-                requirement: .upToNextMajor(from: "2.27.2")),
+        .package(id: "kakao.kakao-ios-sdk", from: "2.27.2"),
         .remote(url: "https://github.com/jdg/MBProgressHUD.git",
                 requirement: .upToNextMajor(from: "1.2.0")),
         .remote(url: "https://github.com/2sem/DownPicker",


### PR DESCRIPTION
## Summary

Migrates eligible SPM packages from `.remote(url:)` to Tuist registry `.package(id:)` format.

## Results

| Package | Result |
|---------|--------|
| `kakao/kakao-ios-sdk` | ✅ Migrated to `kakao.kakao-ios-sdk` |
| `2sem/GADManager` | ❌ Not on registry — kept as `.remote()` |
| `jdg/MBProgressHUD` | ❌ Not on registry — kept as `.remote()` |
| `2sem/DownPicker` | ⏭️ Skipped — uses `.branch()`, incompatible with registry |
| `2sem/LSExtensions` | ❌ Not on registry — kept as `.remote()` |
| `CosmicMind/Material` | ❌ Not on registry — kept as `.remote()` |
| `2sem/LProgressWebViewController` | ❌ Not on registry — kept as `.remote()` |

`DynamicThirdParty/Project.swift` was already fully migrated (SDWebImage, Firebase).

`tuist generate --no-open` passes cleanly.