### PR TITLE
fix: dynamic Crashlytics dSYM upload script for Tuist registry

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -80,6 +80,13 @@ let project = Project(
                                                           "fbauth2"]),
                 ]
             ),
+            sources: ["Sources/**"],
+            resources: [.glob(pattern: "Resources/**",
+                              excluding: [
+                                "Resources/Images/photos/*",
+                                "Resources/Databases/DAModel.xcdatamodeld/**"
+                              ]),
+                        .folderReference(path: "Resources/Images/photos")],
             scripts: [
                 .post(
                     script: "CRASHLYTICS_RUN=$(find \"${BUILD_DIR%/Build/*}/SourcePackages/registry/downloads/firebase/firebase-ios-sdk\" -name run | head -1); \"$CRASHLYTICS_RUN\"",
@@ -94,13 +101,6 @@ let project = Project(
                     runForInstallBuildsOnly: true
                 ),
             ],
-            sources: ["Sources/**"],
-            resources: [.glob(pattern: "Resources/**",
-                              excluding: [
-                                "Resources/Images/photos/*",
-                                "Resources/Databases/DAModel.xcdatamodeld/**"
-                              ]),
-                        .folderReference(path: "Resources/Images/photos")],
             dependencies: [
                 .Projects.ThirdParty,
                 .Projects.DynamicThirdParty,

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -80,6 +80,20 @@ let project = Project(
                                                           "fbauth2"]),
                 ]
             ),
+            scripts: [
+                .post(
+                    script: "CRASHLYTICS_RUN=$(find \"${BUILD_DIR%/Build/*}/SourcePackages/registry/downloads/firebase/firebase-ios-sdk\" -name run | head -1); \"$CRASHLYTICS_RUN\"",
+                    name: "Upload dSYM for Crashlytics",
+                    inputPaths: [
+                        "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+                        "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+                        "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+                        "$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+                        "$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)"
+                    ],
+                    runForInstallBuildsOnly: true
+                ),
+            ],
             sources: ["Sources/**"],
             resources: [.glob(pattern: "Resources/**",
                               excluding: [


### PR DESCRIPTION
## Summary

- Adds "Upload dSYM for Crashlytics" post-build script to the App target
- Uses `find` to locate `Crashlytics/run` dynamically under `registry/downloads/firebase/firebase-ios-sdk/` instead of a hardcoded `checkouts/` path
- `runForInstallBuildsOnly: true` — only runs during archive, not every build

## Root Cause

Migrating `firebase-ios-sdk` to the Tuist registry changed the package storage path from:
```
SourcePackages/checkouts/firebase-ios-sdk/
```
to:
```
SourcePackages/registry/downloads/firebase/firebase-ios-sdk/{version}/
```
The version directory changes on every update, so any hardcoded path breaks at archive time.

## Fix

```swift
.post(
    script: "CRASHLYTICS_RUN=$(find \"${BUILD_DIR%/Build/*}/SourcePackages/registry/downloads/firebase/firebase-ios-sdk\" -name run | head -1); \"$CRASHLYTICS_RUN\"",
    name: "Upload dSYM for Crashlytics",
    inputPaths: [ ... ],
    runForInstallBuildsOnly: true
)
```

## Test Plan
- [ ] Run `tuist generate` and verify the build phase appears in Xcode under App → Build Phases
- [ ] Archive the app and confirm Crashlytics receives dSYMs in Firebase Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)