### PR TITLE
ci: fix iOS GitHub Actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Select Xcode
       run: |
-        sudo xcode-select -s /Applications/Xcode_26.1.1.app
+        sudo xcode-select -s /Applications/Xcode_26.5.app
 
     - name: Install Mise
       uses: jdx/mise-action@v2

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -42,7 +42,7 @@ jobs:
         
       - name: Select Xcode
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.1.1.app
+          sudo xcode-select -s /Applications/Xcode_26.5.app
 
       - name: Import Secret Key
         run: |

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -161,7 +161,8 @@ jobs:
             -workspace $WORKSPACE \
             -scheme "$SCHEME" \
             -configuration Release \
-            -archivePath "$ARCHIVE_PATH"
+            -archivePath "$ARCHIVE_PATH" \
+            -destination "generic/platform=iOS"
             # -allowProvisioningUpdates \
             # CODE_SIGN_STYLE=Manual \
             # DEVELOPMENT_TEAM="$TEAM_ID" \


### PR DESCRIPTION
## Summary
- Use Xcode 26.5 in build/test and deploy workflows
- Set a generic iOS destination for archive builds

## Why
- Deploy succeeded after these workflow fixes on the release branch
- Keeps CI/deploy fixes separate from the app version bump PR

## Verification
- Cherry-picked only workflow fix commits from the release branch
- Diff is limited to `.github/workflows/build-test.yml` and `.github/workflows/deploy-ios.yml`