### PR TITLE
Simplify politician grouping labels

### DIFF
--- a/Projects/App/Sources/ViewModels/PoliticianListViewModel.swift
+++ b/Projects/App/Sources/ViewModels/PoliticianListViewModel.swift
@@ -21,9 +21,9 @@ class PoliticianListViewModel: ObservableObject {
 
         var title: String {
             switch self {
-            case .byName: return "이름별"
-            case .byGroup: return "소속별"
-            case .byArea: return "지역별"
+            case .byName: return "이름"
+            case .byGroup: return "정당"
+            case .byArea: return "지역구"
             }
         }
     }


### PR DESCRIPTION
## Summary
- Rename grouping segmented-control titles from 이름별/소속별/지역별 to 이름/정당/지역구
- Keep grouping behavior unchanged

## Validation
- Ran `mise exec -- tuist generate` successfully before creating this PR
- Reverted incidental `.package.resolved` resolver side effects

## Notes
- This is a text-only UI label change in `PoliticianListViewModel.GroupingType.title`.

## Result
<img width="402" height="307" alt="스크린샷 2026-06-25 오후 8 16 02" src="https://github.com/user-attachments/assets/0724b1ff-6eee-446f-ba25-6f79a570d2de" />
