### PR TITLE
Clarify politician search copy

### DIFF
--- a/Projects/App/Sources/Screens/PoliticianListScreen.swift
+++ b/Projects/App/Sources/Screens/PoliticianListScreen.swift
@@ -29,7 +29,7 @@ struct PoliticianListScreen: View {
                 }
             }
             .navigationBarTitleDisplayMode(.inline)
-            .searchable(text: $viewModel.searchText, prompt: "이름 또는 지역 검색")
+            .searchable(text: $viewModel.searchText, prompt: "이름 또는 지역구 검색")
             .searchScopes($viewModel.searchScope) {
                 ForEach(PoliticianListViewModel.SearchScope.allCases, id: \.self) { scope in
                     Text(scope.title).tag(scope)
@@ -105,11 +105,19 @@ struct PoliticianListScreen: View {
     
     @ViewBuilder
     private func emptyView() -> some View {
-        ContentUnavailableView(
-            "데이터 없음",
-            systemImage: "person.slash",
-            description: Text("국회의원 정보가 여기에 표시됩니다")
-        )
+        if viewModel.searchText.isEmpty {
+            ContentUnavailableView(
+                "데이터 없음",
+                systemImage: "person.slash",
+                description: Text("국회의원 정보가 여기에 표시됩니다")
+            )
+        } else {
+            ContentUnavailableView(
+                "검색 결과가 없습니다",
+                systemImage: "magnifyingglass",
+                description: Text("이름이나 지역구를 다시 확인해 주세요")
+            )
+        }
     }
     
     @ViewBuilder

--- a/Projects/App/Sources/ViewModels/PoliticianListViewModel.swift
+++ b/Projects/App/Sources/ViewModels/PoliticianListViewModel.swift
@@ -37,7 +37,7 @@ class PoliticianListViewModel: ObservableObject {
             switch self {
             case .all: return "모두"
             case .name: return "이름"
-            case .area: return "지역"
+            case .area: return "지역구"
             }
         }
     }


### PR DESCRIPTION
## Summary
- Update search placeholder to say 지역구 instead of 지역
- Rename the area search scope label from 지역 to 지역구
- Show a search-specific empty state when no filtered results match

## Validation
- Ran `mise exec -- tuist generate` successfully
- Reverted incidental `.package.resolved` resolver side effects

## Notes
- Search still filters by name and constituency; party remains a grouping mode, not a search target.
## Result
<img width="385" height="202" alt="스크린샷 2026-06-25 오후 10 35 03" src="https://github.com/user-attachments/assets/c1565f6b-2da2-4b19-93a9-a25c2e08ba30" />
<img width="291" height="182" alt="스크린샷 2026-06-25 오후 10 35 09" src="https://github.com/user-attachments/assets/c65a9e6d-7fee-4206-a857-b642b2986ae7" />
