### PR TITLE
Show data update only while pulling list

### DIFF
--- a/Projects/App/Sources/Screens/PoliticianListScreen.swift
+++ b/Projects/App/Sources/Screens/PoliticianListScreen.swift
@@ -15,12 +15,11 @@ struct PoliticianListScreen: View {
     @EnvironmentObject private var adManager: SwiftUIAdManager
 
     @State var lastVisibleGroupID: String?
+    @State private var isShowingDataUpdateIndicator = false
     
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
-                DataUpdateIndicator()
-                    .background(Color(UIColor.systemBackground))
 
                 if viewModel.groups.isEmpty {
                     emptyView()
@@ -145,6 +144,20 @@ struct PoliticianListScreen: View {
                     .padding()
                 }
                 .listStyle(.plain)
+                .overlay(alignment: .top) {
+                    if isShowingDataUpdateIndicator {
+                        DataUpdateIndicator()
+                            .background(Color(UIColor.systemBackground))
+                            .transition(.opacity.combined(with: .move(edge: .top)))
+                    }
+                }
+                .onScrollGeometryChange(for: Bool.self) { geometry in
+                    geometry.contentOffset.y + geometry.contentInsets.top < -8
+                } action: { _, isPullingDown in
+                    withAnimation(.snappy(duration: 0.2)) {
+                        isShowingDataUpdateIndicator = isPullingDown
+                    }
+                }
                 .onScrollTargetVisibilityChange(idType: String.self, threshold: 0.5) { visibleIds in
                     visibleGroupIds = Set(viewModel.getGroupIds(fromIds: visibleIds))
                     updateLastVisibleGroupID()


### PR DESCRIPTION
## Summary
- Hide the data update indicator from the normal top content
- Show it as a top overlay only while the politician list is pulled downward
- Account for normal scroll view top inset so it does not appear before an actual pull

## Validation
- Attempted `mise exec -- tuist generate`, but local Xcode package resolution is currently blocked by `duplicate key found: Package@swift-5.9.0.swift`
- Attempted `xcodebuild build` with package updates disabled; it is also blocked during package resolution

## Notes
- This is limited to `PoliticianListScreen` UI behavior.
- The indicator uses `onScrollGeometryChange`, matching the app's iOS 18+ deployment target.

## Result
https://github.com/user-attachments/assets/8177d39b-0ef8-4b1e-8ea4-53b703fe186c
