### PR TITLE
Replace politician sort with section jump menu

### DIFF
--- a/Projects/App/Sources/Screens/PoliticianListScreen.swift
+++ b/Projects/App/Sources/Screens/PoliticianListScreen.swift
@@ -10,12 +10,11 @@ import SwiftData
 
 struct PoliticianListScreen: View {
     @StateObject private var viewModel = PoliticianListViewModel()
-    @State var visibleGroupIds: Set<String> = []
     @Query private var allPersons: [Person]
     @EnvironmentObject private var adManager: SwiftUIAdManager
 
-    @State var lastVisibleGroupID: String?
     @State private var isShowingDataUpdateIndicator = false
+    @State private var sectionIDToScroll: String?
     
     var body: some View {
         NavigationStack {
@@ -29,11 +28,6 @@ struct PoliticianListScreen: View {
             }
             .navigationBarTitleDisplayMode(.inline)
             .searchable(text: $viewModel.searchText, prompt: "이름 또는 지역구 검색")
-            .searchScopes($viewModel.searchScope) {
-                ForEach(PoliticianListViewModel.SearchScope.allCases, id: \.self) { scope in
-                    Text(scope.title).tag(scope)
-                }
-            }
             .searchScopes($viewModel.searchScope) {
                 ForEach(PoliticianListViewModel.SearchScope.allCases, id: \.self) { scope in
                     Text(scope.title).tag(scope)
@@ -60,35 +54,23 @@ struct PoliticianListScreen: View {
                     .pickerStyle(.segmented)
                 }
                 
-                // Sort toggle button
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        viewModel.toggleSort()
-                    } label: {
-                        Image(systemName: viewModel.sortIconName)
-                    }
+                    sectionJumpMenu
                 }
             }
             .onChange(of: allPersons) { oldPersons, newPersons in
                 viewModel.updateGroups(withPersons: newPersons)
-                updateLastVisibleGroupID()
             }
             .onChange(of: viewModel.groupingType) { _, _ in
                 viewModel.updateGroups(withPersons: allPersons)
-                updateLastVisibleGroupID()
             }
-            .onChange(of: viewModel.searchText) { oldValue, newValue in
-                viewModel.debouncedRefresh(withPersons: allPersons) {
-                    updateLastVisibleGroupID()
-                }
+            .onChange(of: viewModel.searchText) { _, _ in
+                viewModel.debouncedRefresh(withPersons: allPersons) {}
             }.onChange(of: viewModel.searchScope) { _, _ in
-                viewModel.debouncedRefresh(withPersons: allPersons) {
-                    updateLastVisibleGroupID()
-                }
+                viewModel.debouncedRefresh(withPersons: allPersons) {}
             }
             .task {
                 viewModel.updateGroups(withPersons: allPersons)
-                updateLastVisibleGroupID()
             }
             .navigationDestination(for: Person.self) { person in
                 PersonDetailScreen(person: person)
@@ -97,9 +79,7 @@ struct PoliticianListScreen: View {
     }
     
     func refresh() {
-        visibleGroupIds = []
         viewModel.updateGroups(withPersons: allPersons)
-        updateLastVisibleGroupID()
     }
     
     @ViewBuilder
@@ -122,48 +102,49 @@ struct PoliticianListScreen: View {
     @ViewBuilder
     private func listView() -> some View {
         ScrollViewReader { scrollProxy in
-            ZStack(alignment: .bottomTrailing) {
-                ScrollView {
-                    LazyVStack() {
-                        ForEach(viewModel.groups) { group in //, id: \.id
-                            Section(header: politicianSection(withGroup: group)) {
-                                let nativeAdInterval = 10
-                                ForEach(Array(group.persons.enumerated()), id: \.element.no) { index, person in
-                                    SwiftUI.Group {
-                                        if !viewModel.searchText.isEmpty || group.persons.count >= 10 {
-                                            NativeAdRowView(adUnit: .personListNative, index: index, interval: nativeAdInterval)
-                                        }
-                                        politicianRow(person: person, withGroupId: group.id)
+            ScrollView {
+                LazyVStack {
+                    ForEach(viewModel.groups) { group in //, id: \.id
+                        Section(header: politicianSection(withGroup: group)) {
+                            let nativeAdInterval = 10
+                            ForEach(Array(group.persons.enumerated()), id: \.element.no) { index, person in
+                                SwiftUI.Group {
+                                    if !viewModel.searchText.isEmpty || group.persons.count >= 10 {
+                                        NativeAdRowView(adUnit: .personListNative, index: index, interval: nativeAdInterval)
                                     }
+                                    politicianRow(person: person, withGroupId: group.id)
                                 }
                             }
-                            .id(group.id)
                         }
-                    }
-                    .scrollTargetLayout()
-                    .padding()
-                }
-                .listStyle(.plain)
-                .overlay(alignment: .top) {
-                    if isShowingDataUpdateIndicator {
-                        DataUpdateIndicator()
-                            .background(Color(UIColor.systemBackground))
-                            .transition(.opacity.combined(with: .move(edge: .top)))
+                        .id(group.id)
                     }
                 }
-                .onScrollGeometryChange(for: Bool.self) { geometry in
-                    geometry.contentOffset.y + geometry.contentInsets.top < -8
-                } action: { _, isPullingDown in
-                    withAnimation(.snappy(duration: 0.2)) {
-                        isShowingDataUpdateIndicator = isPullingDown
-                    }
+                .scrollTargetLayout()
+                .padding()
+            }
+            .listStyle(.plain)
+            .overlay(alignment: .top) {
+                if isShowingDataUpdateIndicator {
+                    DataUpdateIndicator()
+                        .background(Color(UIColor.systemBackground))
+                        .transition(.opacity.combined(with: .move(edge: .top)))
                 }
-                .onScrollTargetVisibilityChange(idType: String.self, threshold: 0.5) { visibleIds in
-                    visibleGroupIds = Set(viewModel.getGroupIds(fromIds: visibleIds))
-                    updateLastVisibleGroupID()
+            }
+            .onScrollGeometryChange(for: Bool.self) { geometry in
+                geometry.contentOffset.y + geometry.contentInsets.top < -8
+            } action: { _, isPullingDown in
+                withAnimation(.snappy(duration: 0.2)) {
+                    isShowingDataUpdateIndicator = isPullingDown
+                }
+            }
+            .onChange(of: sectionIDToScroll) { _, sectionID in
+                guard let sectionID else { return }
+
+                withAnimation {
+                    scrollProxy.scrollTo(sectionID, anchor: .top)
                 }
 
-                nextSectionButton(scrollProxy: scrollProxy)
+                sectionIDToScroll = nil
             }
             .id(viewModel.groupingType)
         }
@@ -176,27 +157,6 @@ struct PoliticianListScreen: View {
         }
         .tint(.primary)
         .id(person.id.hashValue.description)
-//            .onScrollVisibilityChange(threshold: 0.5) { isVisible in
-//                if isVisible {
-//                    // Add person to group's visible set
-//                    visiblePersonIds[groupId, default: []].insert(person.no)
-//                    
-//                    print("Visible person: \(person.no) group: \(groupId)")
-//                } else {
-//                    print("Invisible person: \(person.no) group: \(groupId)")
-//                    // Remove person from group's visible set
-//                    visiblePersonIds[groupId]?.remove(person.no)
-//
-//                    // If no persons are visible in this group, remove the group
-//                    if visiblePersonIds[groupId]?.isEmpty == true {
-//                        visiblePersonIds.removeValue(forKey: groupId)
-//                        print("Invisible group: \(groupId)")
-//                    }
-//                }
-//
-//                // Update last visible group
-//                updateLastVisibleGroupID()
-//            }
     }
     
     @ViewBuilder
@@ -217,56 +177,18 @@ struct PoliticianListScreen: View {
         }
     }
 
-        @ViewBuilder
-
-        private func nextSectionButton(scrollProxy: ScrollViewProxy) -> some View {
-
-            // Next section floating button
-
-            if let lastVisibleGroupID, let nextGroup = viewModel.nextGroup(ofGroupWithId: lastVisibleGroupID) {
-
-                Button {
-
-                    withAnimation {
-
-                        scrollProxy.scrollTo(nextGroup.id, anchor: .top)
-
-                    }
-
-                } label: {
-                HStack(spacing: 4) {
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12, weight: .semibold))
-                    Text(nextGroup.title)
-                        .font(.system(size: viewModel.groupingType == .byName ? 20 : 14, weight: .bold))
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.5)
+    private var sectionJumpMenu: some View {
+        Menu {
+            ForEach(viewModel.groups) { group in
+                Button(group.title) {
+                    sectionIDToScroll = group.id
                 }
-                .padding(.init(top: 8, leading: 16, bottom: 8, trailing: 16))
-                .foregroundColor(.white)
-//                .frame(width: viewModel.groupingType == .byName ? 60 : 88, height: 44)
-                .background(Color(red: 0.47, green: 0.56, blue: 0.61)) // #78909c
-                .cornerRadius(5)
-                .shadow(color: .black.opacity(0.3), radius: 4, x: 0, y: 2)
             }
-            .padding(.trailing, 16)
-            .padding(.bottom, 16)
+        } label: {
+            Image(systemName: "list.bullet")
         }
-    }
-    
-    func updateLastVisibleGroupID() {
-        // Find the last visible group by their actual order in viewModel.groups
-        let lastVisibleGroupId = visibleGroupIds
-            .sorted(by: { leftId, rightId in
-                if viewModel.isAscending {
-                    return leftId < rightId
-                } else {
-                    return leftId > rightId
-                }
-            })
-            .last
-
-        self.lastVisibleGroupID = lastVisibleGroupId
+        .disabled(viewModel.groups.isEmpty)
+        .accessibilityLabel("섹션 선택")
     }
 }
 

--- a/Projects/App/Sources/ViewModels/PoliticianListViewModel.swift
+++ b/Projects/App/Sources/ViewModels/PoliticianListViewModel.swift
@@ -51,9 +51,6 @@ class PoliticianListViewModel: ObservableObject {
 
     // MARK: - Published Properties
 
-    /// Sort direction: true = ascending, false = descending
-    @Published var isAscending: Bool = true
-
     /// Search text for filtering
     @Published var searchText: String = ""
 
@@ -82,7 +79,6 @@ class PoliticianListViewModel: ObservableObject {
     @Published var currentChosungIndex: Int = 0
     
     @Published var groups: [PersonGroup] = []
-    var groupIds: Set<String> = []
 
     // MARK: - Constants
 
@@ -94,28 +90,10 @@ class PoliticianListViewModel: ObservableObject {
                                   "광주", "울산", "세종", "강원", "충북", "충남",
                                   "전북", "전남", "경북", "경남", "제주", "비례대표"]
 
-    // MARK: - Computed Properties
-
-    /// Sort icon name for toolbar button
-    var sortIconName: String {
-        isAscending ? "arrow.up.circle" : "arrow.down.circle"
-    }
-    
-    // MARK: - Actions
-    
-    /// Toggle sort direction
-    func toggleSort() {
-        isAscending.toggle()
-        // Re-sort the groups without changing person order within groups
-        sortGroups()
-    }
-    
     /// Apply sorting to persons array
     func sortedPersons(_ persons: [Person]) -> [Person] {
         persons.sorted { left, right in
-            isAscending
-                ? left.name < right.name
-                : left.name > right.name
+            left.name < right.name
         }
     }
     
@@ -156,24 +134,6 @@ class PoliticianListViewModel: ObservableObject {
             case .byArea:
                 self.groups = groupByArea(filteredPersons)
         }
-        
-        updateGroupIds()
-    }
-    
-    private func updateGroupIds() {
-        self.groupIds = Set(self.groups.map{ $0.id })
-    }
-
-    func getGroupIds(fromIds ids: [String]) -> Set<String> {
-        return self.groupIds.intersection(ids)
-    }
-
-    /// Sort groups only, without changing person order within groups
-    private func sortGroups() {
-        groups.sort { left, right in
-            isAscending ? left.id < right.id : left.id > right.id
-        }
-        updateGroupIds()
     }
 
     // MARK: - Private Grouping Helpers
@@ -215,12 +175,6 @@ class PoliticianListViewModel: ObservableObject {
             groups.append(PersonGroup(title: chosung, persons: matchingPersons, group: nil))
         }
         
-        // Sort groups by title according to sort order
-        // Note: allChosungs is already in the correct order, but we need to respect isAscending
-        if !isAscending {
-            groups.reverse()
-        }
-        
         return groups
     }
 
@@ -229,7 +183,7 @@ class PoliticianListViewModel: ObservableObject {
             person.group?.name ?? "소속 없음"
         }
 
-        let sortedKeys = grouped.keys.sorted { isAscending ? $0 < $1 : $0 > $1 }
+        let sortedKeys = grouped.keys.sorted()
 
         return sortedKeys.map { key in
             let personsInGroup = grouped[key] ?? []
@@ -258,32 +212,6 @@ class PoliticianListViewModel: ObservableObject {
             groups.append(PersonGroup(title: area, persons: matchingPersons, group: nil))
         }
 
-        // Sort groups by title according to sort order
-        groups.sort { left, right in
-            isAscending ? left.title < right.title : left.title > right.title
-        }
-
         return groups
-    }
-
-    // MARK: - Chosung Navigation
-
-    /// Get the next section to navigate to (based on last visible section)
-    /// - Parameters:
-    ///   - persons: All persons in the list
-    ///   - lastVisibleSectionID: ID of the last visible section (nil if none visible)
-    /// - Returns: The next section, or nil if at the end
-    func nextGroup(ofGroupWithId groupId: String) -> PersonGroup? {
-        guard !groups.isEmpty else { return nil }
-
-        // If no visible section, return first section
-        let endGroupIndex = groups.index(before: groups.endIndex)
-        guard let indexOfGroup = groups.firstIndex(where: { $0.id == groupId }), indexOfGroup < endGroupIndex else {
-            return nil
-        }
-        
-        let nextGroupIndex = groups.index(after: indexOfGroup)
-
-        return groups[nextGroupIndex]
     }
 }


### PR DESCRIPTION
## Summary
- replace the politician list sort toolbar button with a section jump menu
- remove the floating next-section button and related scroll visibility tracking
- keep politician grouping/search results in the natural ascending section order

## Validation
- ✅ mise exec -- tuist generate
- ✅ xcodebuild build -workspace democracyaction.xcworkspace -scheme App -destination 'generic/platform=iOS Simulator' initially passed before the final cleanup
- ✅ git diff --check
- ⚠️ final local rebuild is blocked during package resolution by Xcode: duplicate key found: 'Package@swift-5.9.0.swift'

## Result
<img width="388" height="426" alt="스크린샷 2026-06-26 오전 10 49 01" src="https://github.com/user-attachments/assets/9802ecb9-4ed6-455b-b121-8372a0306d72" />
<img width="388" height="316" alt="스크린샷 2026-06-26 오전 10 48 40" src="https://github.com/user-attachments/assets/f70a7ae6-eea3-4da5-b117-e0ae02563c8f" />
