### PR TITLE
Add opencode release command

### DIFF
--- a/.opencode/commands/release.md
+++ b/.opencode/commands/release.md
@@ -1,0 +1,30 @@
+---
+description: Prepare a version release PR and deploy that branch to TestFlight.
+---
+
+Goal: prepare a versioned iOS release branch, create a release PR, deploy that branch to TestFlight, monitor the deploy workflow, and report done only after the workflow succeeds.
+
+Workflow:
+1. Check `git status --short --branch`, confirm the current branch is `main`, and ensure `main` is synced with `origin/main`. If tracked unrelated changes exist, stop and ask before continuing.
+2. Determine the release version. If the user provided `a.b.c`, use it exactly; otherwise increment the patch component of the current `MARKETING_VERSION` from `Projects/App/Configs/debug.xcconfig` and `Projects/App/Configs/release.xcconfig`.
+3. Create a branch named exactly the version string, for example `2.1.2`.
+4. Update only `MARKETING_VERSION` in `Projects/App/Configs/debug.xcconfig` and `Projects/App/Configs/release.xcconfig`. Do not change `CURRENT_PROJECT_VERSION`.
+5. Generate concise release notes from relevant merged PRs/commits unless the user supplied release notes.
+6. Inspect `git diff`, `git status`, and `git log --oneline -10`; commit only the two version config files with `chore(release): prepare <a.b.c>`.
+7. Push the branch and create a PR into `main` titled `Release <a.b.c>` with the release notes as the PR body.
+8. Run `.github/workflows/deploy-ios.yml` on that version branch with `isReleasing=false` and `body` set to the release notes:
+
+```bash
+gh workflow run deploy-ios.yml --ref <a.b.c> -f isReleasing=false -f body='<release notes>'
+```
+
+9. Monitor the run with `gh run list --workflow deploy-ios.yml --branch <a.b.c> --limit 5` and `gh run watch <run-id> --exit-status` until completion.
+10. Report done only if the deploy action succeeds. Include the version, branch, PR URL, deploy run URL, and final status.
+
+Constraints:
+- Keep this command project-local only.
+- Load and follow the `release-ios-testflight` skill for details.
+- Preserve unrelated untracked files unless explicitly asked to include them.
+- Do not include unrelated `.package.resolved`, `.opencode`, workbook, photo, or secret changes in the release commit.
+- Do not merge the release PR unless the user explicitly asks.
+- Do not submit for App Store review unless the user explicitly asks; TestFlight uses `isReleasing=false`.

--- a/.opencode/skills/release-ios-testflight/SKILL.md
+++ b/.opencode/skills/release-ios-testflight/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: release-ios-testflight
+description: Use when preparing an iOS TestFlight release branch, bumping MARKETING_VERSION, creating a release PR, running deploy-ios.yml, and monitoring the GitHub Actions deployment.
+---
+
+# Release iOS TestFlight
+
+Use this skill when the user asks to release the next app version, run `/release`, prepare TestFlight, or deploy a version branch.
+
+## Inputs
+
+- Version format: semantic `a.b.c`, for example `2.1.2`.
+- If the user provides a version, use it exactly.
+- If no version is provided, read `MARKETING_VERSION` from both config files and increment the patch version.
+- Release notes may be provided by the user. If not, generate concise release notes from merged PRs and commits since the previous version bump or latest relevant release commit.
+
+## Files To Update
+
+- `Projects/App/Configs/debug.xcconfig`
+- `Projects/App/Configs/release.xcconfig`
+
+Update only `MARKETING_VERSION=<a.b.c>` in both files. Do not change `CURRENT_PROJECT_VERSION`; the deploy workflow/fastlane increments the TestFlight build number.
+
+## Branch And PR
+
+1. Start from a clean `main` synced with `origin/main`.
+2. Create a release branch named exactly the version string, for example `2.1.2`.
+3. Update app version in both xcconfig files.
+4. Commit with message `chore(release): prepare <a.b.c>`.
+5. Push the branch.
+6. Create a PR into `main` titled `Release <a.b.c>`.
+7. Use the release notes as the PR body.
+
+## Validation Before Deploy
+
+- Inspect `git status`, `git diff`, and recent commits before committing.
+- Verify the PR includes only the intended version config changes unless the user explicitly asked for more.
+- Run `git diff --check`.
+- Do not include unrelated `.package.resolved`, `.opencode`, workbook, photo, or secret changes.
+- If local build validation is blocked by known package resolver issues, document the exact blocker in the PR body and final report.
+
+## Deploy To TestFlight
+
+After the PR exists, run the deploy workflow using the version branch as the ref:
+
+```bash
+gh workflow run deploy-ios.yml \
+  --ref <a.b.c> \
+  -f isReleasing=false \
+  -f body='<release notes>'
+```
+
+Use `isReleasing=false` for TestFlight. Do not set `isReleasing=true` unless the user explicitly asks to submit for App Store review.
+
+## Monitor Deployment
+
+1. Find the workflow run for the branch:
+
+```bash
+gh run list --workflow deploy-ios.yml --branch <a.b.c> --limit 5
+```
+
+2. Watch the run until it completes:
+
+```bash
+gh run watch <run-id> --exit-status
+```
+
+3. If the run succeeds, report that the release task is done and include:
+   - Version
+   - Branch
+   - PR URL
+   - Deploy run URL
+   - Final workflow status
+
+4. If the run fails, report the failed step and key error output. Do not claim the task is done.
+
+## Important Rules
+
+- Never merge the release PR unless the user explicitly asks to merge it.
+- Never submit for App Store review unless explicitly requested.
+- Preserve unrelated untracked files.
+- Do not revert user changes.
+- If the working tree has unrelated tracked changes, stop and ask how to proceed before creating the release branch.


### PR DESCRIPTION
## Summary
- add project-local /release command using the markdown command format used by the working loahelper project
- add release-ios-testflight skill with the version bump, PR, TestFlight deploy, and monitoring workflow
- avoid adding a project opencode.json so command discovery stays file-based

## Review
- The command follows the existing .opencode/commands/*.md frontmatter/body pattern.
- The skill uses the expected .opencode/skills/<name>/SKILL.md path and matching frontmatter name.
- The workflow targets deploy-ios.yml with isReleasing=false for TestFlight only.

## Validation
- opencode debug config shows command.release
- git diff --check passed for the new release command and skill

Note: existing local .opencode/commands/update.md and update-data.md remain untracked and are not part of this PR.

## Result
<img width="186" height="82" alt="스크린샷 2026-06-26 오후 11 16 18" src="https://github.com/user-attachments/assets/be85e11f-f7f1-4169-a3cf-5b14fd44567a" />
